### PR TITLE
Network Only strategy for range requests

### DIFF
--- a/lib/misc/sw-template.js
+++ b/lib/misc/sw-template.js
@@ -249,6 +249,11 @@ function WebpackServiceWorker(params, helpers) {
       return;
     }
 
+    // Guarantee Network Only strategy for range requests
+    if (event.request.headers.get('range')) {
+      return;
+    }
+
     // This prevents some weird issue with Chrome DevTools and 'only-if-cached'
     // Fixes issue #385, also ref to:
     // - https://github.com/paulirish/caltrainschedule.io/issues/49

--- a/src/misc/sw-template.js
+++ b/src/misc/sw-template.js
@@ -260,6 +260,11 @@ function WebpackServiceWorker(params, helpers) {
       return;
     }
 
+    // Guarantee Network Only strategy for range requests
+    if (event.request.headers.get('range')) {
+      return;
+    }
+
     // This prevents some weird issue with Chrome DevTools and 'only-if-cached'
     // Fixes issue #385, also ref to:
     // - https://github.com/paulirish/caltrainschedule.io/issues/49


### PR DESCRIPTION
Set up Network Only strategy for range requests in order to prevent incorrect responses from cache on media resource load.